### PR TITLE
:bug: Fix markdown text splitter to allow spaces in links

### DIFF
--- a/libraries/lychee/source/data/MD.js
+++ b/libraries/lychee/source/data/MD.js
@@ -191,7 +191,7 @@ lychee.define('lychee.data.MD').exports(function(lychee, global, attachments) {
 		var last_entity = null;
 
 
-		text.split(/\s/g).forEach(function(str) {
+        text.match(/(\[[^\)]+\)|[^\s]+)/gi).forEach(function(str) {
 
 			var entity = null;
 			var suffix = null;


### PR DESCRIPTION
# New lychee.js Pull Request


## Description of Changes

Related issue: #133 
Fixed splitting of Markdown string to allow spaces inside link descriptor

## Affected Libraries / Projects

Please replace these in order to let us know what you've
worked on:

- **Affected Operating Systems**: `all`
- **Affected Library/Project**: `/libraries/lychee`
- **Affected Issue**: `#133`

## Checklist before Merge

If you've worked on `/libraries/lychee`, the configure
script needs to run in order to rebuild the core.


Check these checkboxes 
Make sure your code runs through with these commands:

- [x] The `sudo ./bin/configure.sh --sandbox` script runs with no errors
- [x] The `lycheejs-harvester start development` profile runs with no errors
- [x] The code style follows the [CODESTYLE guide](./guides/CODESTYLE.md)
- [x] The commit messages follow the [CONTRIBUTION guide](./guides/CONTRIBUTION.md#git-commit-messages)
- [x] The pull-request branch is not named `development` or `2XXX-QX`


